### PR TITLE
Code cleanup: bug fixes and hardening

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Handy Git hooks to integrate with [pre-commit](http://pre-commit.com/) framework
   * Updatd `end-of-file` hook docs
   * Fixed `checkstyle-jar` cache-dir handling when `--jar` is used
   * Declared minimum Python 3.7 and refreshed version classifiers
+  * Added timeout to `checkstyle-jar` JAR download
 
 
 * v1.3.1 (2022-11-07)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Handy Git hooks to integrate with [pre-commit](http://pre-commit.com/) framework
   * Fixed `checkstyle-jar` cache-dir handling when `--jar` is used
   * Declared minimum Python 3.7 and refreshed version classifiers
   * Added timeout to `checkstyle-jar` JAR download
+  * Fixed `trailing-whitespaces` detect-only mode and error handling
 
 
 * v1.3.1 (2022-11-07)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Handy Git hooks to integrate with [pre-commit](http://pre-commit.com/) framework
   * Added type hints to hooks code.umped
   * Bumped Checkstyle to 10.23.1
   * Corrected `trailing-whitespaces` hook's syntax
+  * Updatd `end-of-file` hook docs
 
 
 * v1.3.1 (2022-11-07)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Handy Git hooks to integrate with [pre-commit](http://pre-commit.com/) framework
 
 * dev
   * Added type hints to hooks code.umped
-  * Bumped Checkstyle to 10.23.1
+  * Bumped Checkstyle to 13.4.0
   * Corrected `trailing-whitespaces` hook's syntax
   * Updatd `end-of-file` hook docs
   * Fixed `checkstyle-jar` cache-dir handling when `--jar` is used

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Handy Git hooks to integrate with [pre-commit](http://pre-commit.com/) framework
   * Corrected `trailing-whitespaces` hook's syntax
   * Updatd `end-of-file` hook docs
   * Fixed `checkstyle-jar` cache-dir handling when `--jar` is used
+  * Declared minimum Python 3.7 and refreshed version classifiers
 
 
 * v1.3.1 (2022-11-07)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Handy Git hooks to integrate with [pre-commit](http://pre-commit.com/) framework
 * dev
   * Added type hints to hooks code.umped
   * Bumped Checkstyle to 10.23.1
+  * Corrected `trailing-whitespaces` hook's syntax
 
 
 * v1.3.1 (2022-11-07)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Handy Git hooks to integrate with [pre-commit](http://pre-commit.com/) framework
   * Bumped Checkstyle to 10.23.1
   * Corrected `trailing-whitespaces` hook's syntax
   * Updatd `end-of-file` hook docs
+  * Fixed `checkstyle-jar` cache-dir handling when `--jar` is used
 
 
 * v1.3.1 (2022-11-07)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Handy Git hooks to integrate with [pre-commit](http://pre-commit.com/) framework
   * Declared minimum Python 3.7 and refreshed version classifiers
   * Added timeout to `checkstyle-jar` JAR download
   * Fixed `trailing-whitespaces` detect-only mode and error handling
+  * Hardened `trailing-whitespaces` temp-file naming against races
 
 
 * v1.3.1 (2022-11-07)

--- a/hooks/checkstyle_jar.py
+++ b/hooks/checkstyle_jar.py
@@ -56,21 +56,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if not args.jar_url and not args.jar:
         args.jar_url: str = 'https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.23.1/checkstyle-10.23.1-all.jar'
-    args.cache: Path = Path(args.cache[0]).expanduser()
-    if not args.cache.is_dir():
-        print(f'The --cache must point to writable directory: {args.cache}')
-        return RC_ERROR
 
     if not args.files:
         return RC_OK
 
     if args.jar_url:
+        cache_dir: Path = Path(args.cache[0]).expanduser()
+        cache_dir.mkdir(parents = True, exist_ok = True)
         parsed_url: ParseResult = parse.urlparse(args.jar_url)
         downloaded_jar_filename: str = pathlib.Path(parsed_url.path).name
-        downloaded_jar_path: Path = Path(args.cache).expanduser() / downloaded_jar_filename
-        downloaded_tmp_path: Path = Path(args.cache).expanduser() / f'{downloaded_jar_filename}.tmp'
+        downloaded_jar_path: Path = cache_dir / downloaded_jar_filename
+        downloaded_tmp_path: Path = cache_dir / f'{downloaded_jar_filename}.tmp'
         if not downloaded_jar_path.exists():
-            print(f'Downloading {downloaded_jar_filename} to {args.cache}...')
+            print(f'Downloading {downloaded_jar_filename} to {cache_dir}...')
             path: str
             http: HTTPMessage
             path, http = request.urlretrieve(args.jar_url, downloaded_tmp_path)

--- a/hooks/checkstyle_jar.py
+++ b/hooks/checkstyle_jar.py
@@ -55,7 +55,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         args.jar: Path = Path(args.jar[0]).expanduser()
 
     if not args.jar_url and not args.jar:
-        args.jar_url: str = 'https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.23.1/checkstyle-10.23.1-all.jar'
+        args.jar_url: str = 'https://github.com/checkstyle/checkstyle/releases/download/checkstyle-13.4.0/checkstyle-13.4.0-all.jar'
 
     if not args.files:
         return RC_OK

--- a/hooks/checkstyle_jar.py
+++ b/hooks/checkstyle_jar.py
@@ -13,12 +13,12 @@
 
 import argparse
 import pathlib
+import shutil
 import sys
 from pathlib import Path
 from subprocess import run, CompletedProcess
 from urllib import request, parse
 from urllib.parse import ParseResult
-from http.client import HTTPMessage
 from typing import List, Optional, Sequence
 
 RC_OK: int = 0
@@ -26,6 +26,8 @@ RC_ERROR: int = 1
 RC_FAKE_ERROR_CODE: int = 10
 RC_DOWNLOAD_ERROR: int = 20
 RC_NO_JAR: int = 150
+
+DOWNLOAD_TIMEOUT_SECS: int = 120
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -69,14 +71,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         downloaded_tmp_path: Path = cache_dir / f'{downloaded_jar_filename}.tmp'
         if not downloaded_jar_path.exists():
             print(f'Downloading {downloaded_jar_filename} to {cache_dir}...')
-            path: str
-            http: HTTPMessage
-            path, http = request.urlretrieve(args.jar_url, downloaded_tmp_path)
-            tmp_path: Path = Path(path)
-            if not tmp_path.exists():
-                print(f'Failed to download JAR file: {args.jar_url}')
+            try:
+                with request.urlopen(args.jar_url, timeout = DOWNLOAD_TIMEOUT_SECS) as resp, \
+                        downloaded_tmp_path.open('wb') as out:
+                    shutil.copyfileobj(resp, out)
+            except Exception as ex:
+                downloaded_tmp_path.unlink(missing_ok = True)
+                print(f'Failed to download JAR file: {args.jar_url} ({ex})')
                 return RC_DOWNLOAD_ERROR
-            tmp_path.rename(downloaded_jar_path)
+            downloaded_tmp_path.rename(downloaded_jar_path)
 
         if downloaded_jar_path.exists():
             args.jar: Path = downloaded_jar_path

--- a/hooks/end_of_file.py
+++ b/hooks/end_of_file.py
@@ -1,14 +1,14 @@
 """
-# checkstyle-jar
+# end-of-file
 #
-# Bridges Checkstyle code linter with pre-commit. This hook requires
-# JAR version of Checkstyle and Java environment installed (in $PATH)
+# Ensures that a file is either empty, or ends with exactly one newline.
+# Optionally rewrites offending files in place when --fix=yes is given.
 #
 # Copyright ©2021-2025 Marcin Orlowski <mail [@] MarcinOrlowski.com>
 # https://github.com/MarcinOrlowski/pre-commit-hooks/
 #
 # Test invocation:
-#   pre-commit try-repo . checkstyle-jar --verbose --all-files
+#   pre-commit try-repo . end-of-file --verbose --all-files
 """
 
 import argparse

--- a/hooks/end_of_file.py
+++ b/hooks/end_of_file.py
@@ -13,6 +13,7 @@
 
 import argparse
 import os
+import sys
 from typing import IO
 from typing import Optional
 from typing import Sequence
@@ -95,4 +96,4 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 
 if __name__ == '__main__':
-    exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/hooks/trailing_whitespaces.py
+++ b/hooks/trailing_whitespaces.py
@@ -23,30 +23,23 @@ def gen_tmp_filename(filename: str, suffix: str = 'tmp') -> str:
 
 
 def fix_file(args: argparse.Namespace, filename: str, is_markdown: bool, chars: Optional[bytes]) -> bool:
-    try:
-        with open(filename, mode = 'rb') as rfh:
-            lines: List[bytes] = rfh.readlines()
-            new_lines: List[bytes] = [process_line(line, is_markdown, chars) for line in lines]
-            if new_lines != lines and args.fix:
-                # save modified content to new file
-                save_filename: str = gen_tmp_filename(filename)
-                with open(save_filename, mode = 'wb') as wfh:
-                    _ = [wfh.write(line) for line in new_lines]
+    with open(filename, mode = 'rb') as rfh:
+        lines: List[bytes] = rfh.readlines()
+    new_lines: List[bytes] = [process_line(line, is_markdown, chars) for line in lines]
+    if new_lines == lines:
+        return False
 
-                # rename original file to backup
-                bak_filename: str = gen_tmp_filename(filename, 'bak')
-                os.rename(filename, bak_filename)
-                # rename written file to replace original one
-                os.rename(save_filename, filename)
-                # remove backup file
-                os.unlink(bak_filename)
+    if args.fix:
+        save_filename: str = gen_tmp_filename(filename)
+        with open(save_filename, mode = 'wb') as wfh:
+            wfh.writelines(new_lines)
 
-                return True
-    except Exception as ex:
-        print(f'Exception: {ex}')
-        print(f'File: {filename}')
+        bak_filename: str = gen_tmp_filename(filename, 'bak')
+        os.rename(filename, bak_filename)
+        os.rename(save_filename, filename)
+        os.unlink(bak_filename)
 
-    return False
+    return True
 
 
 def process_line(line: bytes, is_markdown: bool, chars: Optional[bytes]) -> bytes:
@@ -106,7 +99,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     for filename in args.filenames:
         _, extension = os.path.splitext(filename.lower())
         md: bool = all_markdown or extension in md_exts
-        if fix_file(args, filename, md, chars):
+        try:
+            needs_fix: bool = fix_file(args, filename, md, chars)
+        except OSError as ex:
+            print(f'[ERROR] {filename}: {ex}')
+            return_code = 1
+            continue
+        if needs_fix:
             if args.fix:
                 print(f'Fixed {filename}')
             else:

--- a/hooks/trailing_whitespaces.py
+++ b/hooks/trailing_whitespaces.py
@@ -7,6 +7,7 @@
 
 import argparse
 import os
+import sys
 from typing import Optional
 from typing import Sequence
 from typing import List
@@ -119,4 +120,4 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 
 if __name__ == '__main__':
-    exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/hooks/trailing_whitespaces.py
+++ b/hooks/trailing_whitespaces.py
@@ -17,9 +17,13 @@ def gen_tmp_filename(filename: str, suffix: str = 'tmp') -> str:
     idx: int = 0
     while True:
         result_name: str = f'{filename}.{suffix}-{idx}'
-        if not os.path.exists(result_name):
-            return result_name
-        idx += 1
+        try:
+            fd: int = os.open(result_name, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            idx += 1
+            continue
+        os.close(fd)
+        return result_name
 
 
 def fix_file(args: argparse.Namespace, filename: str, is_markdown: bool, chars: Optional[bytes]) -> bool:

--- a/hooks/trailing_whitespaces.py
+++ b/hooks/trailing_whitespaces.py
@@ -88,8 +88,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     all_markdown: bool = '*' in md_args
     # normalize extensions; split at ',', lowercase, and force 1 leading '.'
     md_exts: List[str] = [
-        '.' + x.lower().lstrip('.') for x in ','.join(md_args).split(',')
-    ]
+        '.' + x.lower().lstrip('.') for x in ','.join(md_args).split(',') if x
+    ] if md_args else []
 
     # reject probable "eaten" filename as extension: skip leading '.' with [1:]
     for ext in md_exts:

--- a/hooks/trailing_whitespaces.py
+++ b/hooks/trailing_whitespaces.py
@@ -104,7 +104,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     chars: Optional[bytes] = None if args.chars is None else args.chars.encode()
     return_code: int = 0
     for filename in args.filenames:
-        _, extension: str = os.path.splitext(filename.lower())
+        _, extension = os.path.splitext(filename.lower())
         md: bool = all_markdown or extension in md_exts
         if fix_file(args, filename, md, chars):
             if args.fix:

--- a/setup.py
+++ b/setup.py
@@ -19,16 +19,19 @@ setup(
     platforms = 'linux',
     classifiers = [
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 
+    python_requires = '>=3.7',
     packages = find_packages('.'),
     install_requires = [],
     entry_points = {


### PR DESCRIPTION
## Summary
- Fixed a `SyntaxError` in `trailing-whitespaces` that prevented the hook from loading at all (introduced by the recent type-hint pass).
- Fixed `trailing-whitespaces` detect-only mode (`--fix=no`): previously returned success on dirty files; now correctly reports violations. Also stopped swallowing I/O errors silently.
- Fixed `checkstyle-jar` failing when `--jar` is supplied but the cache dir doesn't exist; cache is now auto-created and only touched when actually downloading.
- Added a 120 s socket timeout to the JAR download (was unbounded).
- Bumped bundled Checkstyle default from 10.23.1 to 13.4.0.
- Hardened `trailing-whitespaces` temp-file naming against TOCTOU races via `O_CREAT|O_EXCL`.
- Declared `python_requires='>=3.7'` and refreshed classifiers through 3.14 (the code uses `subprocess.run(capture_output=...)`, 3.7+).
- Normalized script entry points across all hooks (`sys.exit(main(sys.argv[1:]))`).
- Corrected the copy-pasted Checkstyle docstring at the top of `end_of_file.py`.
- Tidied `md_exts` normalization so the empty default no longer produces `['.']`.
